### PR TITLE
Reference the WpfFormLibrary project instead of the DLL

### DIFF
--- a/SystemTrayApp/SystemTrayApp.csproj
+++ b/SystemTrayApp/SystemTrayApp.csproj
@@ -46,9 +46,6 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="WpfFormLibrary">
-      <HintPath>..\bin\WpfFormLibrary.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeviceManager.cs" />
@@ -89,6 +86,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\NotReadyIcon.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WpfFormLibrary\WpfFormLibrary.csproj">
+      <Project>{ec9652c9-aeec-48ea-bd5d-f00e3c80eabb}</Project>
+      <Name>WpfFormLibrary</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/WpfFormLibrary/WpfFormLibrary.csproj
+++ b/WpfFormLibrary/WpfFormLibrary.csproj
@@ -102,7 +102,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(ProjectDir)$(OutDir)$(TargetFileName) $(SolutionDir)bin\$(TargetFileName)</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Now there is no need for a build event to copy the dll as "copy local" is set on the referenced project.

This fixes the issue that you couldn't clone this repository and then build the solution. The build failed because the bin folder didn't exist in SystemTrayApp and so WpfFormLibrary couldn't build successfully because it had a build event that would fail.